### PR TITLE
user event hooks: adding user_created event hook on user creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,10 @@ class User < ActiveRecord::Base
   after_create :automatic_group_membership
   after_create :set_default_categories_preferences
 
+  after_create do
+    DiscourseEvent.trigger(:user_created, self)
+  end
+
   before_save :update_username_lower
   before_save :ensure_password_is_hashed
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -397,6 +397,11 @@ describe UsersController do
         post_user
         expect(User.find_by(username: @user.username).locale).to eq('fr')
       end
+
+      it 'fires the user_created event hook' do
+        DiscourseEvent.expects(:trigger).with(:user_created, anything).once
+        post_user
+      end
     end
 
     context 'when creating a non active user (unconfirmed email)' do


### PR DESCRIPTION
I am setting up Discourse to run the forum of our [English language learning book club](https://www.owlabc.com). I am using SSO to handle our users and am using the API to generate private categories and groups for our books/units. Then, as our users advance through our system, they are added to the appropriate group, thereby unlocking book/unit specific forum categories as they finish units and books.

However, users that don't yet exist in Discourse can't be added to groups, so I have to do a bulk permission update when the user visits the forum for the first time, specifically waiting until the user is actually created on the Discourse side. Using the [webhooks-plugin](https://meta.discourse.org/t/webhooks-plugin/25176/3), and a user_created event, I have successfully fired a callback to my system when a user is created to check what permissions they should have and then unlock all the book/chapter categories and sub-categories that they should currently see.

It seems like this event hook would have some other use-cases and, in addition, it would be an easy entry contribution to the platform.

RE: [event-hooks-for-discourse](https://meta.discourse.org/t/event-hooks-for-discourse/8296/18)
